### PR TITLE
chore: add GitHub Actions workflow for CI/CD pipeline

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -1,0 +1,23 @@
+name: 'default'
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+permissions:
+  checks: 'write'
+  security-events: 'write'
+  contents: 'write'
+
+jobs:
+  default:
+    uses: 'rios0rios0/pipelines/.github/workflows/go-binary.yaml@main'
+    with:
+      binary_name: 'ronin-to-koinly'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+When a new release is proposed:
+
+1. Create a new branch `bump/x.x.x` (this isn't a long-lived branch!!!);
+2. The Unreleased section on `CHANGELOG.md` gets a version number and date;
+3. Open a Pull Request with the bump version changes targeting the `main` branch;
+4. When the Pull Request is merged, a new Git tag must be created using [GitHub environment](https://github.com/rios0rios0/ronin-to-koinly/tags).
+
+Releases to productive environments should run from a tagged version.
+Exceptions are acceptable depending on the circumstances (critical bug fixes that can be cherry-picked, etc.).
+
+## [Unreleased]
+
+### Added
+
+- added GitHub Actions workflow for CI/CD pipeline

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
         <img src="https://img.shields.io/github/release/rios0rios0/ronin-to-koinly.svg?style=for-the-badge&logo=github" alt="Latest Release"/></a>
     <a href="https://github.com/rios0rios0/ronin-to-koinly/blob/main/LICENSE">
         <img src="https://img.shields.io/github/license/rios0rios0/ronin-to-koinly.svg?style=for-the-badge&logo=github" alt="License"/></a>
+    <a href="https://github.com/rios0rios0/ronin-to-koinly/actions/workflows/default.yaml">
+        <img src="https://img.shields.io/github/actions/workflow/status/rios0rios0/ronin-to-koinly/default.yaml?branch=main&style=for-the-badge&logo=github" alt="Build Status"/></a>
 </p>
 
 A Go application that reads transaction data from the Ronin wallet API and exports it to a CSV file in the Koinly format.


### PR DESCRIPTION
## Summary
- Added `default.yaml` GitHub Actions workflow using the shared `rios0rios0/pipelines` reusable workflows
- Added build status badge to README
- Updated CHANGELOG with the new addition

## Test plan
- [ ] Verify workflow runs successfully on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)