### PR TITLE
docs: standardized CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+Contributions are welcome. By participating, you agree to maintain a respectful and constructive environment.
+
+For coding standards, testing patterns, architecture guidelines, commit conventions, and all
+development practices, refer to the **[Development Guide](https://github.com/rios0rios0/guide/wiki)**.
+
+## Prerequisites
+
+- [Go](https://go.dev/dl/) 1.26+
+
+## Development Workflow
+
+1. Fork and clone the repository
+2. Create a branch: `git checkout -b feat/my-change`
+3. Install dependencies:
+   ```bash
+   go mod download
+   ```
+4. Build the binary:
+   ```bash
+   go build -o bin/ronin-to-koinly .
+   ```
+5. Make your changes
+6. Run tests:
+   ```bash
+   go test ./...
+   ```
+7. Commit following the [commit conventions](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow)
+8. Open a pull request against `main`

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee 
 
 ## Contributing
 
-Contributions are welcome! Please open an issue or submit a pull request for any improvements or bug fixes.
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 


### PR DESCRIPTION
## Summary

- added standardized `CONTRIBUTING.md` referencing the [Development Guide](https://github.com/rios0rios0/guide/wiki)
- updated `README.md` Contributing section to link to `CONTRIBUTING.md`

## Test plan

- [ ] verify `CONTRIBUTING.md` renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)